### PR TITLE
[master] Remove unused module trim-cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 all : inkscape-layers
 
-inkscape-layers : inkscape-layers.cpp trim-cpp/trim.hpp
+inkscape-layers : inkscape-layers.cpp
 	g++ -std=c++11 $^ `pkg-config libxml++-2.6 --cflags --libs` -o $@
 
 clean :

--- a/inkscape-layers.cpp
+++ b/inkscape-layers.cpp
@@ -14,7 +14,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "trim-cpp/trim.hpp"
 
 #define NAME_MODE_DEFAULT 0
 #define NAME_MODE_LABEL   1
@@ -264,7 +263,7 @@ isVisible
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
     style = layer->get_attribute_value("style").raw();
-    Trim::inPlace(style);
+    // Trim::inPlace(style);
 
     if ( (displayBegin = style.find("display")) == std::string::npos ) return true;
     if ( (valueBegin = style.find(':', displayBegin)) == std::string::npos ) return true;
@@ -273,7 +272,7 @@ isVisible
     valueLength = valueEnd - valueBegin;
 
     value = style.substr(valueBegin, valueLength);
-    Trim::inPlace(value);
+    // Trim::inPlace(value);
     return value.compare("none") != 0;
   }
 
@@ -290,7 +289,7 @@ makeVisible
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
     style = layer->get_attribute_value("style").raw();
-    Trim::inPlace(style);
+    // Trim::inPlace(style);
 
     if ( (displayBegin = style.find("display")) == std::string::npos ) return;
     if ( (valueBegin = style.find(':', displayBegin)) == std::string::npos ) return;

--- a/inkscape-layers.cpp
+++ b/inkscape-layers.cpp
@@ -211,7 +211,15 @@ Mode
         if ( outputDirectory.length() == 0 ) outputDirectory = inputFilename.substr(0, pathEnd);
 
         outputBaseName = inputFilename.substr(pathEnd, extensionStart - pathEnd);
+
+        /* HACK :( */
+        /* commented for filename without prefix
         layerFilenamePrefix = outputDirectory + outputBaseName + "-";
+        */
+
+        layerFilenamePrefix = outputDirectory;
+
+        /*KCAH :( */
 
         if ( extensionStart == std::string::npos ) {
           layerFilenameSuffix = "";


### PR DESCRIPTION
Removed missing trim-cpp package call to it from inkscape-layers.cpp. Tested and works. Trim function calls are commented out and no trimming implemented for now. Tried solution proposed in issue "Cannot clone trim-cpp submodule #1"  `ltrim(rtrim(str_variable))` but that did not work.